### PR TITLE
Improve visual group separation

### DIFF
--- a/src/styles/renderer/_aggregate.scss
+++ b/src/styles/renderer/_aggregate.scss
@@ -12,6 +12,10 @@
   }
 }
 
+[data-agg=group] [data-renderer=aggregate] {
+  border-right: 1px solid black;
+}
+
 [data-agg=group] [data-renderer=aggregate]::before {
   content: $fa-var-caret-right;
 }


### PR DESCRIPTION
Closes Caleydo/lineupjs#383

**Implemented as @alexsb suggested** 

![grafik](https://user-images.githubusercontent.com/5851088/31684665-c8821df2-b380-11e7-9fd6-b16fe9ce3f97.png)

Another option would be to use a different color for the aggregated / unaggregated arrows.