### PR TITLE
Assign the column color to the numerical histogram

### DIFF
--- a/src/ui/engine/summary.ts
+++ b/src/ui/engine/summary.ts
@@ -144,7 +144,7 @@ function summaryNumerical(col: INumberColumn & Column, node: HTMLElement, intera
     node.dataset.summary = 'hist';
     node.innerHTML = '';
     stats.hist.forEach(({x, y}, i) => {
-      node.insertAdjacentHTML('beforeend', `<div style="height: ${Math.round(y * 100 / stats.maxBin)}%" title="Bin ${i}: ${y}" data-x="${x}"></div>`);
+      node.insertAdjacentHTML('beforeend', `<div style="height: ${Math.round(y * 100 / stats.maxBin)}%; background-color: ${col.getMetaData().color};" title="Bin ${i}: ${y}" data-x="${x}"></div>`);
     });
     if (isMapAbleColumn(col)) {
       const range = col.getRange();
@@ -170,6 +170,7 @@ function summaryNumerical(col: INumberColumn & Column, node: HTMLElement, intera
     stats.hist.forEach(({x, y}, i) => {
       const bin = bins[i];
       bin.style.height = `${Math.round(y * 100 / stats.maxBin)}%`;
+      bin.style.backgroundColor = col.getMetaData().color;
       bin.title = `Bin ${i}: ${y}`;
       bin.dataset.x = String(x);
     });


### PR DESCRIPTION
Closes Caleydo/lineupjs#423

![image](https://user-images.githubusercontent.com/5851088/32668564-3ef7f450-c63e-11e7-89f1-7bf8b318b13d.png)

@sgratzl: For me choosing a color in the header doesn't work. The selected color from the chooser is not applied as column color. Might there be an event missing?