### PR TITLE
Improve drop area for side panel drag-n-drop

### DIFF
--- a/src/styles/sidePanel/_entry.scss
+++ b/src/styles/sidePanel/_entry.scss
@@ -8,14 +8,44 @@
   background-color: #fff;
   margin-bottom: 0.8em;
 
-  .#{$lu_css_prefix}-sort-handle {
-    display: block;
-    height: 5px;
-    width: 100%;
+  &.#{$lu_css_prefix}-dragover {
+    pointer-events: all !important;
 
-    &.#{$lu_css_prefix}-dragover {
-      background-color: $lu_header_background;
+    & * {
+      pointer-events: none !important;
     }
+  }
+
+  &.#{$lu_css_prefix}-dragover::after {
+    display: none;
+  }
+
+  &::before {
+    content: 'Drop here to change the sorting';
+    position: absolute;
+    z-index: 2;
+    opacity: 0;
+    visibility: hidden;
+    margin-bottom: 0.8em;
+    height: 0;
+    width: 100%;
+    user-select: none;
+    pointer-events: none;
+    font-size: 120%;
+    color: $lu_toolbar_color_hover;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed $lu_drag_over;
+    background-color: lighten($lu_drag_over, 35%);
+    transition: height 0.2s ease, opacity 0.2s ease;
+  }
+
+  &.#{$lu_css_prefix}-dragover::before {
+    position: static;
+    height: 50px;
+    opacity: 1;
+    visibility: visible;
   }
 
   > header {

--- a/src/styles/sidePanel/_entry.scss
+++ b/src/styles/sidePanel/_entry.scss
@@ -13,6 +13,11 @@
 
     & * {
       pointer-events: none !important;
+
+      &::before,
+      &::after {
+        pointer-events: none !important;
+      }
     }
   }
 

--- a/src/ui/panel/SidePanelEntryVis.ts
+++ b/src/ui/panel/SidePanelEntryVis.ts
@@ -32,7 +32,7 @@ export default class SidePanelEntryVis {
     });
 
     dragAbleColumn(<HTMLElement>this.node.querySelector('header'), this.column, this.ctx);
-    resortDropAble(<HTMLElement>this.node.querySelector('.lu-sort-handle')!, this.column, this.ctx, 'before', true);
+    resortDropAble(<HTMLElement>this.node, this.column, this.ctx, 'before', true);
   }
 
   update(ctx: IRankingHeaderContext = this.ctx) {

--- a/src/ui/panel/SidePanelEntryVis.ts
+++ b/src/ui/panel/SidePanelEntryVis.ts
@@ -22,7 +22,7 @@ export default class SidePanelEntryVis {
 
   private init() {
     this.node.innerHTML = `
-      <div class="lu-sort-handle"></div><header><div class="lu-label"></div><div class="lu-toolbar"></div></header>
+      <header><div class="lu-label"></div><div class="lu-toolbar"></div></header>
       <main class="lu-summary"></main>`;
     createToolbar(<HTMLElement>this.node.querySelector('.lu-toolbar'), this.column, this.ctx);
     this.node.querySelector('.lu-label')!.addEventListener('click', (evt) => {


### PR DESCRIPTION
Closes Caleydo/lineupjs#322

I improved the drop areas for the side panel drag and drop:

![better-dnd-sidepanel2](https://user-images.githubusercontent.com/5851088/32740532-8a3249c2-c8a3-11e7-8d56-23938c03b177.gif)


However, there is still an issue, that the drop area is sometimes flickering:

![better-dnd-sidepanel](https://user-images.githubusercontent.com/5851088/32740378-102ad5d6-c8a3-11e7-9d91-f57c63ca59ce.gif)

Technically the CSS class `.lu-dragover` is added and removed rapidly. I assume that another child element "sucks" the events and has an `evt.stopPropagation()`. 

@sgratzl: Do you have an idea how to improve the add/remove of the `.lu-dragover` CSS class?