### PR TITLE
Improve dialog behavior

### DIFF
--- a/src/dialogs/ADialog.ts
+++ b/src/dialogs/ADialog.ts
@@ -27,6 +27,7 @@ class DialogStack {
 
       const mask = dialog.backdropMaskRect();
       if(mask) {
+        // @see http://bennettfeely.com/clippy/ -> select `Frame` example
         (<HTMLElement>this.backdrop.querySelector('.lu-backdrop-mask'))!.style.clipPath = `polygon(
           0% 0%,
           0% 100%,

--- a/src/dialogs/ADialog.ts
+++ b/src/dialogs/ADialog.ts
@@ -2,23 +2,23 @@ import Popper from 'popper.js';
 
 class DialogStack {
 
-  readonly openDialogs:ADialog[] = [];
+  readonly openDialogs: ADialog[] = [];
 
-  private backdrop:HTMLElement;
+  private backdrop: HTMLElement;
 
   private backdropListener = () => {
     this.removeAll();
   };
 
-  private escKeyListener = (evt:KeyboardEvent) => {
+  private escKeyListener = (evt: KeyboardEvent) => {
     if (evt.which === 27 && this.openDialogs.length > 0) {
       this.removeLast();
     }
   };
 
-  add(dialog:ADialog):boolean {
+  add(dialog: ADialog): boolean {
     // add esc listener and backdrop for first dialog
-    if(this.openDialogs.length === 0) {
+    if (this.openDialogs.length === 0) {
       dialog.attachment.ownerDocument.addEventListener('keyup', this.escKeyListener);
 
       dialog.attachment.ownerDocument.body.insertAdjacentHTML('beforeend', `<div class="lu-backdrop"><div class="lu-backdrop-mask"></div></div>`);
@@ -26,7 +26,7 @@ class DialogStack {
       this.backdrop.addEventListener('click', this.backdropListener);
 
       const mask = dialog.backdropMaskRect();
-      if(mask) {
+      if (mask) {
         // @see http://bennettfeely.com/clippy/ -> select `Frame` example
         (<HTMLElement>this.backdrop.querySelector('.lu-backdrop-mask'))!.style.clipPath = `polygon(
           0% 0%,
@@ -42,13 +42,13 @@ class DialogStack {
         )`;
       }
 
-    // check for every further dialog if the same dialog is already open -> if yes, close it == toggle behavior
-    } else if(this.openDialogs[this.openDialogs.length - 1].constructor === dialog.constructor) {
+      // check for every further dialog if the same dialog is already open -> if yes, close it == toggle behavior
+    } else if (this.openDialogs[this.openDialogs.length - 1].constructor === dialog.constructor) {
       this.removeLast();
       return false;
 
-    // if dialogs are not a menu, close previous one before opening the new dialog
-    } else if(!this.openDialogs[this.openDialogs.length - 1].isMenuDialog && !dialog.isMenuDialog) {
+      // if dialogs are not a menu, close previous one before opening the new dialog
+    } else if (!this.openDialogs[this.openDialogs.length - 1].isMenuDialog && !dialog.isMenuDialog) {
       this.removeLast();
     }
 
@@ -56,14 +56,14 @@ class DialogStack {
     return true;
   }
 
-  remove(dialog:ADialog) {
+  remove(dialog: ADialog) {
     const index = this.openDialogs.indexOf(dialog);
-    if(index > -1 && dialog) {
+    if (index > -1 && dialog) {
       this.openDialogs.splice(index, 1);
       dialog.close(false);
     }
 
-    if(this.openDialogs.length > 0) {
+    if (this.openDialogs.length > 0) {
       return;
     }
 
@@ -77,7 +77,7 @@ class DialogStack {
   }
 
   removeAll() {
-    if(this.openDialogs.length === 0) {
+    if (this.openDialogs.length === 0) {
       return;
     }
 
@@ -99,9 +99,9 @@ export interface IMaskRect {
 
 abstract class ADialog {
 
-  public isMenuDialog:boolean = false;
+  public isMenuDialog: boolean = false;
 
-  public backdropMaskRect:() => IMaskRect;
+  public backdropMaskRect: () => IMaskRect;
 
   public node: HTMLElement;
 
@@ -111,10 +111,10 @@ abstract class ADialog {
 
   }
 
-  protected abstract build():HTMLElement;
+  protected abstract build(): HTMLElement;
 
   open(): void {
-    if(!dialogStack.add(this)) {
+    if (!dialogStack.add(this)) {
       return; // not added because of toggle behavior
     }
 
@@ -130,10 +130,10 @@ abstract class ADialog {
     });
   }
 
-  close(removeFromStack:boolean = true): void {
+  close(removeFromStack: boolean = true): void {
     this.popper.destroy();
 
-    if(removeFromStack) {
+    if (removeFromStack) {
       dialogStack.remove(this);
     }
   }
@@ -144,7 +144,7 @@ abstract class ADialog {
    * @param body
    * @returns {HTMLElement}
    */
-  protected makeMenuPopup(body: string):HTMLElement {
+  protected makeMenuPopup(body: string): HTMLElement {
     const parent = this.attachment.ownerDocument.body;
     parent.insertAdjacentHTML('beforeend', `<div class="lu-popup2 lu-popup-menu">${body}</div>`);
     return <HTMLElement>parent.lastElementChild!;
@@ -155,7 +155,7 @@ abstract class ADialog {
    * @param body
    * @returns {HTMLElement}
    */
-  protected makePopup(body: string):HTMLElement {
+  protected makePopup(body: string): HTMLElement {
     const parent = this.attachment.ownerDocument.body;
     parent.insertAdjacentHTML('beforeend', `<div class="lu-popup2">${this.dialogForm(body)}</div>`);
     const popup = <HTMLElement>parent.lastElementChild!;
@@ -168,7 +168,7 @@ abstract class ADialog {
     return popup;
   }
 
-  protected makeChoosePopup(body: string):HTMLElement {
+  protected makeChoosePopup(body: string): HTMLElement {
     const parent = this.attachment.ownerDocument.body;
     parent.insertAdjacentHTML('beforeend', `<div class="lu-popup2 chooser">${this.basicDialog(body)}</div>`);
     return <HTMLElement>parent.lastElementChild!;
@@ -185,7 +185,7 @@ abstract class ADialog {
             </form>`;
   }
 
-  protected onButton(node:HTMLElement, handler: { submit: () => boolean, reset: () => void, cancel: () => void }) {
+  protected onButton(node: HTMLElement, handler: { submit: () => boolean, reset: () => void, cancel: () => void }) {
     node.querySelector('.cancel')!.addEventListener('click', (evt) => {
       handler.cancel();
       dialogStack.remove(this);

--- a/src/dialogs/ADialog.ts
+++ b/src/dialogs/ADialog.ts
@@ -70,10 +70,13 @@ const dialogStack = new DialogStack();
 
 abstract class ADialog {
 
+  public isMenuDialog:boolean = false;
+
   public node: HTMLElement;
-  protected popper: Popper;
+  private popper: Popper;
 
   constructor(public readonly attachment: HTMLElement, private readonly title: string) {
+
   }
 
   protected abstract build():HTMLElement;
@@ -120,7 +123,7 @@ abstract class ADialog {
    * @param body
    * @returns {HTMLElement}
    */
-  makePopup(body: string):HTMLElement {
+  protected makePopup(body: string):HTMLElement {
     const parent = this.attachment.ownerDocument.body;
     parent.insertAdjacentHTML('beforeend', `<div class="lu-popup2">${this.dialogForm(body)}</div>`);
     const popup = <HTMLElement>parent.lastElementChild!;
@@ -133,13 +136,13 @@ abstract class ADialog {
     return popup;
   }
 
-  makeChoosePopup(body: string):HTMLElement {
+  protected makeChoosePopup(body: string):HTMLElement {
     const parent = this.attachment.ownerDocument.body;
     parent.insertAdjacentHTML('beforeend', `<div class="lu-popup2 chooser">${this.basicDialog(body)}</div>`);
     return <HTMLElement>parent.lastElementChild!;
   }
 
-  dialogForm(body: string, addCloseButtons: boolean = true) {
+  protected dialogForm(body: string, addCloseButtons: boolean = true) {
     return `<span style="font-weight: bold" class="lu-popup-title">${this.title}</span>
             <form onsubmit="return false">
                 ${body}

--- a/src/dialogs/ADialog.ts
+++ b/src/dialogs/ADialog.ts
@@ -22,6 +22,7 @@ class DialogStack {
       dialog.attachment.ownerDocument.addEventListener('keyup', this.escKeyListener);
 
       dialog.attachment.ownerDocument.body.insertAdjacentHTML('beforeend', `<div class="lu-backdrop"></div>`);
+      //style="clip-path: polygon(0% 0%, 0% 100%, 25% 100%, 25% 25%, 75% 25%, 75% 75%, 25% 75%, 25% 100%, 100% 100%, 100% 0%);"
       this.backdrop = <HTMLElement>dialog.attachment.ownerDocument.body.lastElementChild!;
       this.backdrop.addEventListener('click', this.backdropListener);
 
@@ -29,6 +30,10 @@ class DialogStack {
     } else if(this.openDialogs[this.openDialogs.length - 1].constructor === dialog.constructor) {
       this.removeLast();
       return false;
+
+    // if dialogs are not a menu, close previous one before opening the new dialog
+    } else if(!this.openDialogs[this.openDialogs.length - 1].isMenuDialog && !dialog.isMenuDialog) {
+      this.removeLast();
     }
 
     this.openDialogs.push(dialog);

--- a/src/dialogs/ADialog.ts
+++ b/src/dialogs/ADialog.ts
@@ -21,10 +21,25 @@ class DialogStack {
     if(this.openDialogs.length === 0) {
       dialog.attachment.ownerDocument.addEventListener('keyup', this.escKeyListener);
 
-      dialog.attachment.ownerDocument.body.insertAdjacentHTML('beforeend', `<div class="lu-backdrop"></div>`);
-      //style="clip-path: polygon(0% 0%, 0% 100%, 25% 100%, 25% 25%, 75% 25%, 75% 75%, 25% 75%, 25% 100%, 100% 100%, 100% 0%);"
+      dialog.attachment.ownerDocument.body.insertAdjacentHTML('beforeend', `<div class="lu-backdrop"><div class="lu-backdrop-mask"></div></div>`);
       this.backdrop = <HTMLElement>dialog.attachment.ownerDocument.body.lastElementChild!;
       this.backdrop.addEventListener('click', this.backdropListener);
+
+      const mask = dialog.backdropMaskRect();
+      if(mask) {
+        (<HTMLElement>this.backdrop.querySelector('.lu-backdrop-mask'))!.style.clipPath = `polygon(
+          0% 0%,
+          0% 100%,
+          ${mask.left}px 100%,
+          ${mask.left}px ${mask.top}px,
+          ${mask.right}px ${mask.top}px,
+          ${mask.right}px ${mask.bottom}px,
+          ${mask.left}px ${mask.bottom}px,
+          ${mask.left}px 100%,
+          100% 100%,
+          100% 0%
+        )`;
+      }
 
     // check for every further dialog if the same dialog is already open -> if yes, close it == toggle behavior
     } else if(this.openDialogs[this.openDialogs.length - 1].constructor === dialog.constructor) {
@@ -72,12 +87,21 @@ class DialogStack {
 // single instance
 const dialogStack = new DialogStack();
 
+export interface IMaskRect {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
 
 abstract class ADialog {
 
   public isMenuDialog:boolean = false;
 
+  public backdropMaskRect:() => IMaskRect;
+
   public node: HTMLElement;
+
   private popper: Popper;
 
   constructor(public readonly attachment: HTMLElement, private readonly title: string) {

--- a/src/dialogs/ADialog.ts
+++ b/src/dialogs/ADialog.ts
@@ -63,11 +63,13 @@ class DialogStack {
       dialog.close(false);
     }
 
-    if(this.openDialogs.length === 0) {
-      dialog.attachment.ownerDocument.removeEventListener('keyup', this.escKeyListener);
-      this.backdrop.removeEventListener('click', this.backdropListener);
-      this.backdrop.remove();
+    if(this.openDialogs.length > 0) {
+      return;
     }
+
+    dialog.attachment.ownerDocument.removeEventListener('keyup', this.escKeyListener);
+    this.backdrop.removeEventListener('click', this.backdropListener);
+    this.backdrop.remove();
   }
 
   removeLast() {
@@ -126,7 +128,7 @@ abstract class ADialog {
       placement: 'bottom-start',
       removeOnDestroy: true
     });
-  };
+  }
 
   close(removeFromStack:boolean = true): void {
     this.popper.destroy();
@@ -134,7 +136,7 @@ abstract class ADialog {
     if(removeFromStack) {
       dialogStack.remove(this);
     }
-  };
+  }
 
 
   /**

--- a/src/dialogs/BooleanFilterDialog.ts
+++ b/src/dialogs/BooleanFilterDialog.ts
@@ -13,7 +13,7 @@ export default class BooleanFilterDialog extends AFilterDialog<BooleanColumn> {
     super(column, header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const bak = this.column.getFilter();
 
     const popup = this.makePopup(`<label><input type="radio" name="boolean_check" value="null" ${bak === null ? 'checked="checked"' : ''}>No Filter</label><br>

--- a/src/dialogs/BooleanFilterDialog.ts
+++ b/src/dialogs/BooleanFilterDialog.ts
@@ -13,7 +13,7 @@ export default class BooleanFilterDialog extends AFilterDialog<BooleanColumn> {
     super(column, header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const bak = this.column.getFilter();
 
     const popup = this.makePopup(`<label><input type="radio" name="boolean_check" value="null" ${bak === null ? 'checked="checked"' : ''}>No Filter</label><br>
@@ -48,5 +48,7 @@ export default class BooleanFilterDialog extends AFilterDialog<BooleanColumn> {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/CategoricalFilterDialog.ts
+++ b/src/dialogs/CategoricalFilterDialog.ts
@@ -14,7 +14,7 @@ export default class CategoricalFilterDialog extends AFilterDialog<CategoricalCo
     super(column, header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const bakOri = this.column.getFilter() || {filter: this.column.categories.slice(), filterMissing: false};
     const bak = <string[]>bakOri.filter || this.column.categories.slice();
     const bakMissing = bakOri.filterMissing;

--- a/src/dialogs/CategoricalFilterDialog.ts
+++ b/src/dialogs/CategoricalFilterDialog.ts
@@ -14,7 +14,7 @@ export default class CategoricalFilterDialog extends AFilterDialog<CategoricalCo
     super(column, header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const bakOri = this.column.getFilter() || {filter: this.column.categories.slice(), filterMissing: false};
     const bak = <string[]>bakOri.filter || this.column.categories.slice();
     const bakMissing = bakOri.filterMissing;
@@ -83,10 +83,12 @@ export default class CategoricalFilterDialog extends AFilterDialog<CategoricalCo
         if (f.length === trData.length) { // all checked = no filter
           f = null;
         }
-        const filterMissing = (<HTMLInputElement>popup.querySelector('input[type="checkbox"].lu_filter_missing')!).checked;
+        const filterMissing = (<HTMLInputElement>this.node.querySelector('input[type="checkbox"].lu_filter_missing')!).checked;
         updateData(f, filterMissing);
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/CategoricalMappingFilterDialog.ts
+++ b/src/dialogs/CategoricalMappingFilterDialog.ts
@@ -16,7 +16,7 @@ export default class CategoricalMappingFilterDialog extends AFilterDialog<Catego
     super(column, header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const bakOri = this.column.getFilter() || {filter: [], filterMissing: false};
     const bak = <string[]>bakOri.filter;
     const bakMissing = bakOri.filterMissing;

--- a/src/dialogs/CategoricalMappingFilterDialog.ts
+++ b/src/dialogs/CategoricalMappingFilterDialog.ts
@@ -16,7 +16,7 @@ export default class CategoricalMappingFilterDialog extends AFilterDialog<Catego
     super(column, header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const bakOri = this.column.getFilter() || {filter: [], filterMissing: false};
     const bak = <string[]>bakOri.filter;
     const bakMissing = bakOri.filterMissing;
@@ -117,5 +117,7 @@ export default class CategoricalMappingFilterDialog extends AFilterDialog<Catego
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/ChangeRendererDialog.ts
+++ b/src/dialogs/ChangeRendererDialog.ts
@@ -9,7 +9,7 @@ export default class ChangeRendererDialog extends ADialog {
     super(header, 'Visualization');
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const current = this.column.getRendererType();
 
     const currentGroup = this.column.getGroupRenderer();

--- a/src/dialogs/ChangeRendererDialog.ts
+++ b/src/dialogs/ChangeRendererDialog.ts
@@ -4,11 +4,12 @@ import {IRankingHeaderContext} from '../ui/engine/interfaces';
 
 
 export default class ChangeRendererDialog extends ADialog {
+
   constructor(private readonly column: Column, header: HTMLElement, private readonly ctx: IRankingHeaderContext) {
     super(header, 'Visualization');
   }
 
-  openDialog() {
+  build():HTMLElement {
     const current = this.column.getRendererType();
 
     const currentGroup = this.column.getGroupRenderer();
@@ -37,5 +38,8 @@ export default class ChangeRendererDialog extends ADialog {
     Array.from(popup.querySelectorAll('input[name="grouptype"]')).forEach((n: HTMLInputElement) => {
       n.addEventListener('change', () => this.column.setGroupRenderer(n.value));
     });
+
+    return popup;
   }
+
 }

--- a/src/dialogs/CompositeChildrenDialog.ts
+++ b/src/dialogs/CompositeChildrenDialog.ts
@@ -13,7 +13,7 @@ export default class CompositeChildrenDialog extends ADialog {
     this.isMenuDialog = true;
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const popup = this.makePopup(`<div class="lu-sub-nested"></div>`);
 
     const wrapper = <HTMLDivElement>popup.querySelector('.lu-sub-nested')!;

--- a/src/dialogs/CompositeChildrenDialog.ts
+++ b/src/dialogs/CompositeChildrenDialog.ts
@@ -11,7 +11,7 @@ export default class CompositeChildrenDialog extends ADialog {
     super(header, '');
   }
 
-  openDialog() {
+  build():HTMLElement {
     const popup = this.makePopup(`<div class="lu-sub-nested"></div>`);
 
     const wrapper = <HTMLDivElement>popup.querySelector('.lu-sub-nested')!;
@@ -57,5 +57,7 @@ export default class CompositeChildrenDialog extends ADialog {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/CompositeChildrenDialog.ts
+++ b/src/dialogs/CompositeChildrenDialog.ts
@@ -9,6 +9,8 @@ export default class CompositeChildrenDialog extends ADialog {
 
   constructor(private readonly column: CompositeColumn, header: HTMLElement, private ctx: IRankingHeaderContext) {
     super(header, '');
+
+    this.isMenuDialog = true;
   }
 
   build():HTMLElement {

--- a/src/dialogs/CutOffHierarchyDialog.ts
+++ b/src/dialogs/CutOffHierarchyDialog.ts
@@ -13,7 +13,7 @@ export default class CutOffHierarchyDialog extends ADialog {
     super(header, 'Edit Hierarchy Cutoff');
   }
 
-  openDialog() {
+  build():HTMLElement {
     const bak = this.column.getCutOff();
     const innerNodes = resolveInnerNodes(this.column.hierarchy);
     const innerNodePaths = innerNodes.map((n) => n.path);
@@ -22,7 +22,7 @@ export default class CutOffHierarchyDialog extends ADialog {
         <input type="number" value="${isFinite(bak.maxDepth) ? bak.maxDepth : ''}" placeholder="max depth (&infin;)"><br>
         <datalist id="ui${this.idPrefix}lineupHierarchyList">${innerNodes.map((node) => `<option value="${node.path}">${node.label}</option>`)}</datalist>`;
 
-    const popup = this.makePopup(t, false);
+    const popup = this.makePopup(t);
 
     //custom validation
     popup.querySelector('input[type="text"]')!.addEventListener('change', function (this: HTMLInputElement) {
@@ -52,5 +52,7 @@ export default class CutOffHierarchyDialog extends ADialog {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/CutOffHierarchyDialog.ts
+++ b/src/dialogs/CutOffHierarchyDialog.ts
@@ -13,7 +13,7 @@ export default class CutOffHierarchyDialog extends ADialog {
     super(header, 'Edit Hierarchy Cutoff');
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const bak = this.column.getCutOff();
     const innerNodes = resolveInnerNodes(this.column.hierarchy);
     const innerNodePaths = innerNodes.map((n) => n.path);

--- a/src/dialogs/EditLinkDialog.ts
+++ b/src/dialogs/EditLinkDialog.ts
@@ -15,7 +15,7 @@ export default class EditLinkDialog extends ADialog {
     super(header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     let t = `<input
         type="text"
         size="15"
@@ -40,5 +40,7 @@ export default class EditLinkDialog extends ADialog {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/EditLinkDialog.ts
+++ b/src/dialogs/EditLinkDialog.ts
@@ -15,7 +15,7 @@ export default class EditLinkDialog extends ADialog {
     super(header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     let t = `<input
         type="text"
         size="15"

--- a/src/dialogs/MappingsFilterDialog.ts
+++ b/src/dialogs/MappingsFilterDialog.ts
@@ -3,8 +3,6 @@ import {IMapAbleColumn, IMappingFunction} from '../model/NumberColumn';
 import Column from '../model/Column';
 import {IDataProvider} from '../provider/ADataProvider';
 import MappingEditor from '../mappingeditor';
-import Popper from 'popper.js';
-import ADialog from './ADialog';
 import {noNumberFilter} from '../model/INumberColumn';
 
 export default class MappingsFilterDialog extends AFilterDialog<IMapAbleColumn & Column> {
@@ -21,7 +19,7 @@ export default class MappingsFilterDialog extends AFilterDialog<IMapAbleColumn &
     super(column, header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const original = this.column.getOriginalMapping();
     let bakfilter = this.column.getFilter(),
       bak = this.column.getMapping(),
@@ -70,12 +68,6 @@ export default class MappingsFilterDialog extends AFilterDialog<IMapAbleColumn &
       }
     });
 
-    const popper = new Popper(this.attachment, popup, {
-      placement: 'bottom-start',
-      removeOnDestroy: true
-    });
-
-    ADialog.registerPopup(popup, popper, false);
-    this.hidePopupOnClickOutside(popup);
+    return popup;
   }
 }

--- a/src/dialogs/MappingsFilterDialog.ts
+++ b/src/dialogs/MappingsFilterDialog.ts
@@ -19,7 +19,7 @@ export default class MappingsFilterDialog extends AFilterDialog<IMapAbleColumn &
     super(column, header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const original = this.column.getOriginalMapping();
     let bakfilter = this.column.getFilter(),
       bak = this.column.getMapping(),

--- a/src/dialogs/MoreColumnOptionsDialog.ts
+++ b/src/dialogs/MoreColumnOptionsDialog.ts
@@ -1,5 +1,5 @@
 import Column from '../model/Column';
-import ADialog from './ADialog';
+import ADialog, {IMaskRect} from './ADialog';
 import {addIconDOM, createToolbarMenuItems} from '../ui/engine/header';
 import {IRankingHeaderContext} from '../ui/engine/interfaces';
 
@@ -12,8 +12,9 @@ export default class MoreColumnOptionsDialog extends ADialog {
    * @param header the visual header element of this column
    * @param title optional title
    * @param ctx
+   * @param backdropMaskRect
    */
-  constructor(readonly column: Column, header: HTMLElement, title = 'More', private ctx: IRankingHeaderContext) {
+  constructor(readonly column: Column, header: HTMLElement, title = 'More', private ctx: IRankingHeaderContext, public backdropMaskRect:() => IMaskRect) {
     super(header, title);
 
     this.isMenuDialog = true;

--- a/src/dialogs/MoreColumnOptionsDialog.ts
+++ b/src/dialogs/MoreColumnOptionsDialog.ts
@@ -20,7 +20,7 @@ export default class MoreColumnOptionsDialog extends ADialog {
     this.isMenuDialog = true;
   }
 
-  build() {
+  protected build() {
     const popup = this.makeMenuPopup('');
     popup.classList.add('lu-more-options');
 

--- a/src/dialogs/MoreColumnOptionsDialog.ts
+++ b/src/dialogs/MoreColumnOptionsDialog.ts
@@ -15,6 +15,8 @@ export default class MoreColumnOptionsDialog extends ADialog {
    */
   constructor(readonly column: Column, header: HTMLElement, title = 'More', private ctx: IRankingHeaderContext) {
     super(header, title);
+
+    this.isMenuDialog = true;
   }
 
   build() {

--- a/src/dialogs/MoreColumnOptionsDialog.ts
+++ b/src/dialogs/MoreColumnOptionsDialog.ts
@@ -17,10 +17,12 @@ export default class MoreColumnOptionsDialog extends ADialog {
     super(header, title);
   }
 
-  openDialog() {
+  build() {
     const popup = this.makeMenuPopup('');
     popup.classList.add('lu-more-options');
 
     createToolbarMenuItems(<any>addIconDOM(popup, this.column, true), this.column, this.ctx);
+
+    return popup;
   }
 }

--- a/src/dialogs/RenameDialog.ts
+++ b/src/dialogs/RenameDialog.ts
@@ -14,11 +14,11 @@ export default class RenameDialog extends ADialog {
     super(header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const popup = this.makePopup(`
       <input type="text" value="${this.column.label}" required autofocus placeholder="name">
       <input type="color" value="${this.column.color}" required placeholder="color">
-      <textarea rows="5">${this.column.description}</textarea><br>`, false
+      <textarea rows="5">${this.column.description}</textarea><br>`
     );
     popup.classList.add('lu-rename-dialog');
 
@@ -33,5 +33,7 @@ export default class RenameDialog extends ADialog {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/RenameDialog.ts
+++ b/src/dialogs/RenameDialog.ts
@@ -14,7 +14,7 @@ export default class RenameDialog extends ADialog {
     super(header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const popup = this.makePopup(`
       <input type="text" value="${this.column.label}" required autofocus placeholder="name">
       <input type="color" value="${this.column.color}" required placeholder="color">

--- a/src/dialogs/ScriptEditDialog.ts
+++ b/src/dialogs/ScriptEditDialog.ts
@@ -14,7 +14,7 @@ export default class ScriptEditDialog extends ADialog {
     super(header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const bak = this.column.getScript();
     const popup = this.makePopup(`<div class="script-description">
       <p>You can write any valid JavaScript code. It will be embedded in a function. Therefore the last statement has to return a value.
@@ -79,5 +79,7 @@ export default class ScriptEditDialog extends ADialog {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/ScriptEditDialog.ts
+++ b/src/dialogs/ScriptEditDialog.ts
@@ -14,7 +14,7 @@ export default class ScriptEditDialog extends ADialog {
     super(header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const bak = this.column.getScript();
     const popup = this.makePopup(`<div class="script-description">
       <p>You can write any valid JavaScript code. It will be embedded in a function. Therefore the last statement has to return a value.

--- a/src/dialogs/SearchDialog.ts
+++ b/src/dialogs/SearchDialog.ts
@@ -15,7 +15,7 @@ export default class SearchDialog extends ADialog {
     super(header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const popup = this.makePopup('<input type="text" size="15" value="" required autofocus placeholder="search..."><br><label><input type="checkbox">RegExp</label><br>');
 
     const input = <HTMLInputElement>popup.querySelector('input[type="text"]')!;
@@ -41,7 +41,7 @@ export default class SearchDialog extends ADialog {
         }
         this.provider.searchAndJump(search, this.column);
       }
-      ADialog.removePopup(popup);
+      //ADialog.removePopup(popup);
     };
 
     checkbox.addEventListener('change', updateImpl);
@@ -54,5 +54,7 @@ export default class SearchDialog extends ADialog {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/SearchDialog.ts
+++ b/src/dialogs/SearchDialog.ts
@@ -35,13 +35,13 @@ export default class SearchDialog extends ADialog {
     const updateImpl = () => {
       let search: string|RegExp = input.value;
       const isRegex = checkbox.checked;
-      if (search.length > 0) {
-        if (isRegex) {
-          search = new RegExp(search);
-        }
-        this.provider.searchAndJump(search, this.column);
+      if (search.length === 0) {
+        return;
       }
-      //ADialog.removePopup(popup);
+      if (isRegex) {
+        search = new RegExp(search);
+      }
+      this.provider.searchAndJump(search, this.column);
     };
 
     checkbox.addEventListener('change', updateImpl);

--- a/src/dialogs/SearchDialog.ts
+++ b/src/dialogs/SearchDialog.ts
@@ -15,7 +15,7 @@ export default class SearchDialog extends ADialog {
     super(header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const popup = this.makePopup('<input type="text" size="15" value="" required autofocus placeholder="search..."><br><label><input type="checkbox">RegExp</label><br>');
 
     const input = <HTMLInputElement>popup.querySelector('input[type="text"]')!;

--- a/src/dialogs/SortDialog.ts
+++ b/src/dialogs/SortDialog.ts
@@ -9,7 +9,7 @@ export default class SortDialog extends ADialog {
     super(header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const bak = this.column.getSortMethod();
     const valueString = Object.keys(this.column instanceof BoxPlotColumn ? SORT_METHOD: ADVANCED_SORT_METHOD);
 
@@ -36,6 +36,8 @@ export default class SortDialog extends ADialog {
         }
       });
     });
+
+    return popup;
   }
 
 }

--- a/src/dialogs/SortDialog.ts
+++ b/src/dialogs/SortDialog.ts
@@ -9,7 +9,7 @@ export default class SortDialog extends ADialog {
     super(header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const bak = this.column.getSortMethod();
     const valueString = Object.keys(this.column instanceof BoxPlotColumn ? SORT_METHOD: ADVANCED_SORT_METHOD);
 

--- a/src/dialogs/SortGroupDialog.ts
+++ b/src/dialogs/SortGroupDialog.ts
@@ -6,7 +6,7 @@ export default class SortDialog extends ADialog {
     super(header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const bak = this.column.getSortMethod();
     const valueString = ['name', 'count'];
 
@@ -29,6 +29,8 @@ export default class SortDialog extends ADialog {
         this.column.groupSortByMe(n.value === 'asc');
       });
     });
+
+    return popup;
   }
 
 }

--- a/src/dialogs/SortGroupDialog.ts
+++ b/src/dialogs/SortGroupDialog.ts
@@ -1,8 +1,9 @@
-import ADialog from './ADialog';
+import ADialog, {IMaskRect} from './ADialog';
 import GroupColumn from '../model/GroupColumn';
 
 export default class SortDialog extends ADialog {
-  constructor(private readonly column: GroupColumn, header: HTMLElement, title = 'Change Sort Criteria') {
+
+  constructor(private readonly column: GroupColumn, header: HTMLElement, title = 'Change Sort Criteria', public backdropMaskRect:() => IMaskRect) {
     super(header, title);
   }
 

--- a/src/dialogs/SortGroupDialog.ts
+++ b/src/dialogs/SortGroupDialog.ts
@@ -7,7 +7,7 @@ export default class SortDialog extends ADialog {
     super(header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const bak = this.column.getSortMethod();
     const valueString = ['name', 'count'];
 

--- a/src/dialogs/StratifyThresholdDialog.ts
+++ b/src/dialogs/StratifyThresholdDialog.ts
@@ -12,7 +12,7 @@ export default class StratifyThresholdDialog extends ADialog {
     super(header, 'Stratify by Threshold');
   }
 
-  openDialog() {
+  build():HTMLElement {
     if (this.column.isGroupedBy() >= 0) {
       // disable grouping
       this.column.groupByMe();
@@ -44,5 +44,7 @@ export default class StratifyThresholdDialog extends ADialog {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/dialogs/StratifyThresholdDialog.ts
+++ b/src/dialogs/StratifyThresholdDialog.ts
@@ -1,4 +1,4 @@
-import ADialog from './ADialog';
+import ADialog, {IMaskRect} from './ADialog';
 import NumberColumn from '../model/NumberColumn';
 
 export default class StratifyThresholdDialog extends ADialog {
@@ -7,8 +7,9 @@ export default class StratifyThresholdDialog extends ADialog {
    * opens a dialog for editing the link of a column
    * @param column the column to rename
    * @param header the visual header element of this column
+   * @param backdropMaskRect
    */
-  constructor(private readonly column: NumberColumn, header: HTMLElement) {
+  constructor(private readonly column: NumberColumn, header: HTMLElement, public backdropMaskRect:() => IMaskRect) {
     super(header, 'Stratify by Threshold');
   }
 

--- a/src/dialogs/StratifyThresholdDialog.ts
+++ b/src/dialogs/StratifyThresholdDialog.ts
@@ -16,7 +16,7 @@ export default class StratifyThresholdDialog extends ADialog {
     if (this.column.isGroupedBy() >= 0) {
       // disable grouping
       this.column.groupByMe();
-      return;
+      return this.attachment.ownerDocument.createElement('div');
     }
     const domain = this.column.getOriginalMapping().domain;
     const bak = this.column.getStratifyThresholds();

--- a/src/dialogs/StratifyThresholdDialog.ts
+++ b/src/dialogs/StratifyThresholdDialog.ts
@@ -13,7 +13,7 @@ export default class StratifyThresholdDialog extends ADialog {
     super(header, 'Stratify by Threshold');
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     if (this.column.isGroupedBy() >= 0) {
       // disable grouping
       this.column.groupByMe();

--- a/src/dialogs/StringFilterDialog.ts
+++ b/src/dialogs/StringFilterDialog.ts
@@ -13,7 +13,7 @@ export default class StringFilterDialog extends AFilterDialog<StringColumn> {
     super(column, header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const base = stringFilter(this.column);
     const popup = this.makePopup(base.template);
 
@@ -38,6 +38,8 @@ export default class StringFilterDialog extends AFilterDialog<StringColumn> {
         return true;
       }
     });
+
+    return popup;
   }
 }
 

--- a/src/dialogs/StringFilterDialog.ts
+++ b/src/dialogs/StringFilterDialog.ts
@@ -13,7 +13,7 @@ export default class StringFilterDialog extends AFilterDialog<StringColumn> {
     super(column, header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const base = stringFilter(this.column);
     const popup = this.makePopup(base.template);
 

--- a/src/dialogs/WeightsEditDialog.ts
+++ b/src/dialogs/WeightsEditDialog.ts
@@ -13,7 +13,7 @@ export default class WeightsEditDialog extends ADialog {
     super(header, title);
   }
 
-  build():HTMLElement {
+  protected build():HTMLElement {
     const weights = this.column.getWeights();
     const children = this.column.children.map((d, i) => ({col: d, weight: Math.round(weights[i] * 100)} ));
 

--- a/src/dialogs/WeightsEditDialog.ts
+++ b/src/dialogs/WeightsEditDialog.ts
@@ -13,7 +13,7 @@ export default class WeightsEditDialog extends ADialog {
     super(header, title);
   }
 
-  openDialog() {
+  build():HTMLElement {
     const weights = this.column.getWeights();
     const children = this.column.children.map((d, i) => ({col: d, weight: Math.round(weights[i] * 100)} ));
 
@@ -56,5 +56,7 @@ export default class WeightsEditDialog extends ADialog {
         return true;
       }
     });
+
+    return popup;
   }
 }

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -4,6 +4,11 @@
 @import 'vars';
 
 @at-root {
+  @keyframes dialogs-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
   .#{$lu_css_prefix}-backdrop {
     position: fixed;
     top: 0;
@@ -20,7 +25,7 @@
       right: 0;
       bottom: 0;
       background: rgba(0, 0, 0, 0.1);
-      animation: fade-in 0.2s;
+      animation: dialogs-fade-in 0.2s;
     }
   }
 
@@ -44,6 +49,7 @@
     z-index: 9;
     font-size: $lu_dialog_font_size;
     clear: right;
+    animation: dialogs-fade-in 0.4s;
 
     form {
       display: block;

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -6,7 +6,7 @@
 @at-root {
   @keyframes dialogs-fade-in {
     from { opacity: 0; }
-    to   { opacity: 1; }
+    to { opacity: 1; }
   }
 
   .#{$lu_css_prefix}-backdrop {

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -4,6 +4,18 @@
 @import 'vars';
 
 @at-root {
+  .#{$lu_css_prefix}-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 8;
+    display: block;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.1);
+    animation: fade-in 0.2s;
+  }
+
   .#{$lu_css_prefix}-popup {
     position: absolute;
     dominant-baseline: central;
@@ -24,16 +36,6 @@
     z-index: 9;
     font-size: $lu_dialog_font_size;
     clear: right;
-
-    &::before {
-      content: '';
-      top: -$lu_dialog_mouse_region;
-      left: -$lu_dialog_mouse_region;
-      right: -$lu_dialog_mouse_region;
-      bottom: -$lu_dialog_mouse_region;
-      position: absolute;
-      z-index: -1;
-    }
 
     form {
       display: block;

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -12,8 +12,16 @@
     display: block;
     width: 100vw;
     height: 100vh;
-    background: rgba(0, 0, 0, 0.1);
-    animation: fade-in 0.2s;
+
+    > .#{$lu_css_prefix}-backdrop-mask {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.1);
+      animation: fade-in 0.2s;
+    }
   }
 
   .#{$lu_css_prefix}-popup {

--- a/src/ui/HeaderRenderer.ts
+++ b/src/ui/HeaderRenderer.ts
@@ -17,7 +17,7 @@ import DataProvider, {IDataRow} from '../provider/ADataProvider';
 import SelectionColumn from '../model/SelectionColumn';
 import {createShortcutMenuItems, MIMETYPE_PREFIX, toFullTooltip} from './engine/header';
 import {defaultConfig, dummyRankingButtonHook} from '../config';
-import ADialog, {dialogStack} from '../dialogs/ADialog';
+import ADialog from '../dialogs/ADialog';
 import {IRankingHeaderContext} from './engine/interfaces';
 import {IHeaderRendererOptions} from './interfaces';
 import NumberColumn from '../model/NumberColumn';
@@ -289,7 +289,7 @@ export default class HeaderRenderer {
         proxy.onclick = (evt: MouseEvent) => {
           evt.stopPropagation();
           const dialog = new dialogClass(col, (<HTMLElement>evt.currentTarget).parentElement!, ...dialogArgs);
-          dialogStack.add(dialog);
+          dialog.open();
         };
         return proxy;
       };

--- a/src/ui/HeaderRenderer.ts
+++ b/src/ui/HeaderRenderer.ts
@@ -17,7 +17,7 @@ import DataProvider, {IDataRow} from '../provider/ADataProvider';
 import SelectionColumn from '../model/SelectionColumn';
 import {createShortcutMenuItems, MIMETYPE_PREFIX, toFullTooltip} from './engine/header';
 import {defaultConfig, dummyRankingButtonHook} from '../config';
-import ADialog from '../dialogs/ADialog';
+import ADialog, {IMaskRect} from '../dialogs/ADialog';
 import {IRankingHeaderContext} from './engine/interfaces';
 import {IHeaderRendererOptions} from './interfaces';
 import NumberColumn from '../model/NumberColumn';
@@ -293,7 +293,12 @@ export default class HeaderRenderer {
         };
         return proxy;
       };
-      createShortcutMenuItems(addIcon, col, ctx);
+      const dialogBackdropMask:() => IMaskRect = () => {
+        const mask = this.getBoundingClientRect();
+        // manipulate bottom to highlight the whole column (and not only the header)
+        return {top: mask.top, left: mask.left, right: mask.right, bottom: document.body.clientHeight};
+      };
+      createShortcutMenuItems(addIcon, col, ctx, dialogBackdropMask);
     });
   }
 

--- a/src/ui/HeaderRenderer.ts
+++ b/src/ui/HeaderRenderer.ts
@@ -17,7 +17,7 @@ import DataProvider, {IDataRow} from '../provider/ADataProvider';
 import SelectionColumn from '../model/SelectionColumn';
 import {createShortcutMenuItems, MIMETYPE_PREFIX, toFullTooltip} from './engine/header';
 import {defaultConfig, dummyRankingButtonHook} from '../config';
-import ADialog from '../dialogs/ADialog';
+import ADialog, {dialogStack} from '../dialogs/ADialog';
 import {IRankingHeaderContext} from './engine/interfaces';
 import {IHeaderRendererOptions} from './interfaces';
 import NumberColumn from '../model/NumberColumn';
@@ -289,7 +289,7 @@ export default class HeaderRenderer {
         proxy.onclick = (evt: MouseEvent) => {
           evt.stopPropagation();
           const dialog = new dialogClass(col, (<HTMLElement>evt.currentTarget).parentElement!, ...dialogArgs);
-          dialog.openDialog();
+          dialogStack.add(dialog);
         };
         return proxy;
       };

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -9,7 +9,7 @@ import SortDialog from '../../dialogs/SortDialog';
 import RenameDialog from '../../dialogs/RenameDialog';
 import ChangeRendererDialog from '../../dialogs/ChangeRendererDialog';
 import LinkColumn from '../../model/LinkColumn';
-import ADialog, {dialogStack} from '../../dialogs/ADialog';
+import ADialog from '../../dialogs/ADialog';
 import ScriptColumn from '../../model/ScriptColumn';
 import ScriptEditDialog from '../../dialogs/ScriptEditDialog';
 import EditLinkDialog from '../../dialogs/EditLinkDialog';
@@ -133,7 +133,7 @@ export function addIconDOM(node: HTMLElement, col: Column, showLabel: boolean) {
     i.onclick = (evt) => {
       evt.stopPropagation();
       const dialog = new dialogClass(col, i, ...dialogArgs);
-      dialogStack.add(dialog);
+      dialog.open();
     };
     return i;
   };

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -9,7 +9,7 @@ import SortDialog from '../../dialogs/SortDialog';
 import RenameDialog from '../../dialogs/RenameDialog';
 import ChangeRendererDialog from '../../dialogs/ChangeRendererDialog';
 import LinkColumn from '../../model/LinkColumn';
-import ADialog from '../../dialogs/ADialog';
+import ADialog, {dialogStack} from '../../dialogs/ADialog';
 import ScriptColumn from '../../model/ScriptColumn';
 import ScriptEditDialog from '../../dialogs/ScriptEditDialog';
 import EditLinkDialog from '../../dialogs/EditLinkDialog';
@@ -133,7 +133,7 @@ export function addIconDOM(node: HTMLElement, col: Column, showLabel: boolean) {
     i.onclick = (evt) => {
       evt.stopPropagation();
       const dialog = new dialogClass(col, i, ...dialogArgs);
-      dialog.openDialog();
+      dialogStack.add(dialog);
     };
     return i;
   };

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -9,7 +9,7 @@ import SortDialog from '../../dialogs/SortDialog';
 import RenameDialog from '../../dialogs/RenameDialog';
 import ChangeRendererDialog from '../../dialogs/ChangeRendererDialog';
 import LinkColumn from '../../model/LinkColumn';
-import ADialog from '../../dialogs/ADialog';
+import ADialog, {IMaskRect} from '../../dialogs/ADialog';
 import ScriptColumn from '../../model/ScriptColumn';
 import ScriptEditDialog from '../../dialogs/ScriptEditDialog';
 import EditLinkDialog from '../../dialogs/EditLinkDialog';
@@ -72,7 +72,14 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
     <div class="lu-summary"></div>
     <div class="lu-handle"></div>
   `;
-  createToolbar(<HTMLElement>node.querySelector('div.lu-toolbar')!, col, ctx);
+
+  const dialogBackdropMask:() => IMaskRect = () => {
+    const mask = node.getBoundingClientRect();
+    // manipulate bottom to highlight the whole column (and not only the header)
+    return {top: mask.top, left: mask.left, right: mask.right, bottom: document.body.clientHeight};
+  };
+
+  createToolbar(<HTMLElement>node.querySelector('div.lu-toolbar')!, col, ctx, dialogBackdropMask);
 
   toggleToolbarIcons(node, col);
 
@@ -139,15 +146,15 @@ export function addIconDOM(node: HTMLElement, col: Column, showLabel: boolean) {
   };
 }
 
-export function createToolbar(node: HTMLElement, col: Column, ctx: IRankingHeaderContext) {
-  return createShortcutMenuItems(<any>addIconDOM(node, col, false), col, ctx);
+export function createToolbar(node: HTMLElement, col: Column, ctx: IRankingHeaderContext, dialogBackdropMask:() => IMaskRect) {
+  return createShortcutMenuItems(<any>addIconDOM(node, col, false), col, ctx, dialogBackdropMask);
 }
 
 interface IAddIcon {
   (title: string, dialogClass?: { new(col: any, header: HTMLElement, ...args: any[]): ADialog }, ...dialogArgs: any[]): { onclick: (evt: { stopPropagation: () => void, currentTarget: Element, [key: string]: any }) => any };
 }
 
-export function createShortcutMenuItems(addIcon: IAddIcon, col: Column, ctx: IRankingHeaderContext) {
+export function createShortcutMenuItems(addIcon: IAddIcon, col: Column, ctx: IRankingHeaderContext, dialogBackdropMask:() => IMaskRect) {
 
   if (!isSupportType(col.desc) || col instanceof SelectionColumn) {
     addIcon('Sort').onclick = (evt) => {
@@ -157,7 +164,7 @@ export function createShortcutMenuItems(addIcon: IAddIcon, col: Column, ctx: IRa
   }
 
   if (col instanceof GroupColumn) {
-    addIcon('Sort Group by &hellip;', SortGroupDialog);
+    addIcon('Sort Group by &hellip;', SortGroupDialog, dialogBackdropMask);
   }
 
   //stratify
@@ -169,7 +176,7 @@ export function createShortcutMenuItems(addIcon: IAddIcon, col: Column, ctx: IRa
   }
 
   if (col instanceof NumberColumn) {
-    addIcon('Stratify by Threshold &hellip;', StratifyThresholdDialog);
+    addIcon('Stratify by Threshold &hellip;', StratifyThresholdDialog, dialogBackdropMask);
   }
 
   if (!(col instanceof RankColumn)) {
@@ -184,7 +191,7 @@ export function createShortcutMenuItems(addIcon: IAddIcon, col: Column, ctx: IRa
     };
   }
 
-  addIcon('More &hellip;', MoreColumnOptionsDialog, '', ctx);
+  addIcon('More &hellip;', MoreColumnOptionsDialog, '', ctx, dialogBackdropMask);
 }
 
 export function createToolbarMenuItems(addIcon: IAddIcon, col: Column, ctx: IRankingHeaderContext) {

--- a/src/ui/panel/SidePanelEntryVis.ts
+++ b/src/ui/panel/SidePanelEntryVis.ts
@@ -4,6 +4,7 @@
 import Column from '../../model/Column';
 import {createToolbar, dragAbleColumn, updateHeader} from '../engine/header';
 import {IRankingHeaderContext} from '../engine/interfaces';
+import {IMaskRect} from '../../dialogs/ADialog';
 
 
 export default class SidePanelEntryVis {
@@ -24,7 +25,12 @@ export default class SidePanelEntryVis {
     this.node.innerHTML = `
       <header><div class="lu-label"></div><div class="lu-toolbar"></div></header>
       <main class="lu-summary"></main>`;
-    createToolbar(<HTMLElement>this.node.querySelector('.lu-toolbar'), this.column, this.ctx);
+
+    const dialogBackdropMask:() => IMaskRect = () => {
+      return this.node.getBoundingClientRect();
+    };
+
+    createToolbar(<HTMLElement>this.node.querySelector('.lu-toolbar'), this.column, this.ctx, dialogBackdropMask);
     dragAbleColumn(<HTMLElement>this.node.querySelector('header'), this.column, this.ctx);
     // resortDropAble(<HTMLElement>this.node, this.column, this.ctx, 'before', false);
   }


### PR DESCRIPTION
Closes #495

Dialogs are closed on click (instead of moving away with the mouse). The current column is highlighted, the rest is getting slightly darker. For the menu in the side panel the current option is highlighted, since there is no reference of the DOM element of the related column.

![image](https://user-images.githubusercontent.com/5851088/35668733-e8d98a80-0732-11e8-834c-1380809ef498.png)

![taggle-dialog-click](https://user-images.githubusercontent.com/5851088/35668742-f014a37a-0732-11e8-87aa-8a1c2b6363ae.gif)
