### PR TITLE
In 'Sort group by ...' Median is selected by default, even if not sorted

### DIFF
--- a/src/dialogs/SortDialog.ts
+++ b/src/dialogs/SortDialog.ts
@@ -20,7 +20,7 @@ export default class SortDialog extends ADialog {
     }).join('\n');
     const sortOrders = `
         <label><input type="radio" name="sortorder" value="asc"  ${(order === 'asc') ? 'checked' : ''} > Ascending</label><br>
-        <label><input type="radio" name="sortorder" value="desc"  ${(order === 'desc') ? 'checked' : ''} > Decending</label><br>`;
+        <label><input type="radio" name="sortorder" value="desc"  ${(order === 'desc' || !order) ? 'checked' : ''} > Decending</label><br>`;
 
     const popup = this.makeChoosePopup( `${sortMethods}<strong>Sort Order</strong><br>${sortOrders}`);
 

--- a/src/model/NumberColumn.ts
+++ b/src/model/NumberColumn.ts
@@ -10,7 +10,7 @@ import {isMissingValue, isUnknown, missingGroup} from './missing';
 import {IGroupData} from '../ui/engine/interfaces';
 import {
   default as INumberColumn, INumberDesc, numberCompare, groupCompare,
-  SortMethod, ADVANCED_SORT_METHOD, INumberFilter, noNumberFilter, isSameFilter, restoreFilter
+  SortMethod, INumberFilter, noNumberFilter, isSameFilter, restoreFilter
 } from './INumberColumn';
 
 export {default as INumberColumn, isNumberColumn} from './INumberColumn';
@@ -274,7 +274,7 @@ export default class NumberColumn extends ValueColumn<number> implements INumber
   private numberFormat: (n: number) => string = format('.2f');
 
   private currentStratifyThresholds: number[] = [];
-  private groupSortMethod: SortMethod = ADVANCED_SORT_METHOD.median;
+  private groupSortMethod: SortMethod = '';
 
   constructor(id: string, desc: INumberColumnDesc) {
     super(id, desc);


### PR DESCRIPTION
related issues:   https://github.com/Caleydo/tdp_bi_bioinfodb/issues/796

### Pre merge/review checklist
* [x] branch is up-to-date with the branch to be merged with, i.e. master
* [x] travis build works
* [x] internal code review by requester is done:
  * [x] code is formatted
  * [x] removed debug output `console.log`, ...
  * [x] use of `readonly` for readonly fields and interfaces fields
  * [x] parameters, fields, variables that are not initialized are typed, e.g.,  `function f(a)` => `function f(a: number)` 
  * [x] optional options objects are typed using option interfaces, see e.g. `ILineUpConfig`
  * [x] code is formatted using your preferred editor formatting tool (e.g. atom beautifier, WebStorm Format Code,...)
  * [x] use of meaningful names in camelCase especially for public functions and fields
  * [x] file structure: avoid of large code files containing multiple elements (classes, functions) better to create a nested structure, e.g., `model`
  * [x] in case of DOM elements: assigning the `id` is avoided or the prefix in the lineup config is prepended
  * [x] in case of css styles: global classes prepended with `lu-` or within a `lu-` namespace
  * [x] public fields/function those purpose is not obvious are documented
  * [x] complex code is documented
  * [x] code is well structured regarding use of variable names, complexity
  * [x] public interfaces (e.g. public interface of a class) are minimal, no superfluous fields, functions
  * [x] complex code is not duplicated. Otherwise justified within the code, why needed
 * [x] code reviewer is assigned
 * [ ] in case of second review round: review comments are justified or implemented
 
