### PR TITLE
Mark guessed columns - Caleydo/lineup: issue 25

### DIFF
--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -120,7 +120,7 @@ export interface IRendererInfo {
   groupRenderer: string;
 }
 
-export enum EGuessedState{
+export enum EGuessedState {
   unknown,
   guessed,
   checked
@@ -207,7 +207,7 @@ export default class Column extends AEventDispatcher {
 
     if (typeof desc.guessed === 'undefined') {
       this.guessed = EGuessedState.unknown;
-    }else{
+    } else {
       this.guessed = desc.guessed;
     }
   }

--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -121,9 +121,9 @@ export interface IRendererInfo {
 }
 
 export enum EGuessedState {
-  unknown,
-  guessed,
-  checked
+  UNKNOWN,
+  GUESSED,
+  CHECKED
 }
 
 
@@ -203,7 +203,7 @@ export default class Column extends AEventDispatcher {
     };
 
     if (typeof desc.guessed === 'undefined') {
-      this.guessed = EGuessedState.unknown;
+      this.guessed = EGuessedState.UNKNOWN;
     } else {
       this.guessed = desc.guessed;
     }

--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -84,7 +84,7 @@ export interface IColumnDesc {
   /**
    * flag if column type was guessed
    */
-  readonly guessed?: boolean;
+  readonly guessed?: EGuessedState;
 }
 
 export interface IStatistics {
@@ -118,6 +118,12 @@ export interface IRendererInfo {
   renderer: string;
 
   groupRenderer: string;
+}
+
+export enum EGuessedState{
+  unknown,
+  guessed,
+  checked
 }
 
 
@@ -182,7 +188,7 @@ export default class Column extends AEventDispatcher {
 
   private readonly rendererInfo: IRendererInfo;
 
-  guessed: boolean = null;
+  guessed: EGuessedState;
 
   constructor(id: string, public readonly desc: IColumnDesc) {
     super();
@@ -199,7 +205,11 @@ export default class Column extends AEventDispatcher {
       color: desc.color || (this.cssClass !== '' ? null : Column.DEFAULT_COLOR)
     };
 
-    this.guessed = desc.guessed;
+    if (typeof desc.guessed === 'undefined') {
+      this.guessed = EGuessedState.unknown;
+    }else{
+      this.guessed = desc.guessed;
+    }
   }
 
   get id() {

--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -159,9 +159,6 @@ export default class Column extends AEventDispatcher {
   static readonly EVENT_VISBILITY_CHANGED = 'visibilityChanged';
   static readonly EVENT_DATA_LOADED = 'dataLoaded';
 
-  static readonly GUESSED_ICON = 'times';
-  static readonly CONFIRMED_ICON = 'check';
-
   /**
    * the id of this column
    */

--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -80,6 +80,11 @@ export interface IColumnDesc {
    * default group renderer to use
    */
   readonly groupRenderer?: string;
+
+  /**
+   * flag if column type was guessed
+   */
+  readonly guessed?: boolean;
 }
 
 export interface IStatistics {
@@ -148,6 +153,9 @@ export default class Column extends AEventDispatcher {
   static readonly EVENT_VISBILITY_CHANGED = 'visibilityChanged';
   static readonly EVENT_DATA_LOADED = 'dataLoaded';
 
+  static readonly GUESSED_ICON = 'times';
+  static readonly CONFIRMED_ICON = 'check';
+
   /**
    * the id of this column
    */
@@ -174,6 +182,7 @@ export default class Column extends AEventDispatcher {
 
   private readonly rendererInfo: IRendererInfo;
 
+  guessed: boolean = null;
 
   constructor(id: string, public readonly desc: IColumnDesc) {
     super();
@@ -189,6 +198,8 @@ export default class Column extends AEventDispatcher {
       description: desc.description || '',
       color: desc.color || (this.cssClass !== '' ? null : Column.DEFAULT_COLOR)
     };
+
+    this.guessed = desc.guessed;
   }
 
   get id() {

--- a/src/styles/engine/_header.scss
+++ b/src/styles/engine/_header.scss
@@ -58,6 +58,12 @@ section.#{$lu_css_prefix}-header {
     > i {
       position: absolute;
       right: 0.5em;
+      cursor: default;
+      color: $lu_toolbar_color_base2;
+
+      &:hover {
+        color: $lu_toolbar_color_hover;
+      }
     }
   }
 

--- a/src/styles/engine/_header.scss
+++ b/src/styles/engine/_header.scss
@@ -52,14 +52,14 @@ section.#{$lu_css_prefix}-header {
     font-weight: 500;
 
     &.has-marker {
-      margin-right: 1em;
+      margin-right: 18px;
     }
 
     > i {
       position: absolute;
-      right: 0.5em;
+      right: 6px;
       cursor: default;
-      color: $lu_toolbar_color_base2;
+      color: $lu_toolbar_color_base;
 
       &:hover {
         color: $lu_toolbar_color_hover;

--- a/src/styles/engine/_header.scss
+++ b/src/styles/engine/_header.scss
@@ -50,6 +50,15 @@ section.#{$lu_css_prefix}-header {
     padding-left: $lu-engine_grip_gap;
     margin-right: $lu-engine_grip_gap;
     font-weight: 500;
+
+    &.has-marker {
+      margin-right: 1em;
+    }
+
+    > i {
+      position: absolute;
+      right: 0.5em;
+    }
   }
 
   > .#{$lu_css_prefix}-sort {

--- a/src/styles/header/_index.scss
+++ b/src/styles/header/_index.scss
@@ -15,6 +15,17 @@
     white-space: nowrap;
     overflow-x: hidden;
     text-overflow: ellipsis;
+
+    > i {
+      padding-top: 2px;
+      margin-left: 6px;
+      cursor: default;
+      color: $lu_toolbar_color_base;
+
+      &:hover {
+        color: $lu_toolbar_color_hover;
+      }
+    }
   }
 
   &.#{$lu_css_prefix}-dragging {

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -1,7 +1,7 @@
 /**
  * Created by Samuel Gratzl on 25.07.2017.
  */
-import Column from '../../model/Column';
+import Column, {EGuessedState} from '../../model/Column';
 import {createNestedDesc, createStackDesc, isSupportType} from '../../model';
 import NumbersColumn from '../../model/NumbersColumn';
 import BoxPlotColumn from '../../model/BoxPlotColumn';
@@ -73,8 +73,8 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
     <div class="lu-handle"></div>
   `;
 
-  if(typeof col.guessed !== 'undefined' && col.guessed !== null) {
-    node.querySelector('.lu-label').innerHTML += `<i class="fa fa-${col.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
+  if(col.guessed !== EGuessedState.unknown) {
+    node.querySelector('.lu-label').innerHTML += `<i class="fa fa-${col.guessed === EGuessedState.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
   }
 
   const dialogBackdropMask:() => IMaskRect = () => {
@@ -104,8 +104,8 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
 
 export function updateHeader(node: HTMLElement, col: Column, ctx: IRankingHeaderContext, interactive: boolean = false) {
   let labelInnerHTML = col.label;
-  if(typeof col.guessed !== 'undefined' && col.guessed !== null) {
-    labelInnerHTML += `<i class="fa fa-${col.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
+  if(col.guessed !== EGuessedState.unknown) {
+    labelInnerHTML += `<i class="fa fa-${col.guessed === EGuessedState.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
   }
   node.querySelector('.lu-label')!.innerHTML = labelInnerHTML;
   node.title = toFullTooltip(col);

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -57,6 +57,22 @@ export interface IHeaderOptions {
   resizeable: boolean;
 }
 
+function importMarker(state: EGuessedState): string {
+  if(state === EGuessedState.unknown) {
+    return '';
+  }
+
+  let icon = 'fa-check';
+  let title = `The imported data type has been confirmed.`;
+
+  if(state === EGuessedState.guessed) {
+    icon = 'fa-question';
+    title = `The imported data type was guessed automatically.`;
+  }
+
+  return `<i class="fa ${icon}" title="${title}"></i>`;
+}
+
 export function createHeader(col: Column, document: Document, ctx: IRankingHeaderContext, options: Partial<IHeaderOptions> = {}) {
   options = Object.assign({
     dragAble: true,
@@ -75,7 +91,7 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
 
   if(col.guessed !== EGuessedState.unknown) {
     const labelElement = node.querySelector('.lu-label');
-    labelElement!.innerHTML += `<i class="fa fa-${col.guessed === EGuessedState.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
+    labelElement!.innerHTML += importMarker(col.guessed);
     labelElement!.classList.add('has-marker');
   }
 
@@ -105,11 +121,7 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
 }
 
 export function updateHeader(node: HTMLElement, col: Column, ctx: IRankingHeaderContext, interactive: boolean = false) {
-  let labelInnerHTML = col.label;
-  if(col.guessed !== EGuessedState.unknown) {
-    labelInnerHTML += `<i class="fa fa-${col.guessed === EGuessedState.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
-  }
-  node.querySelector('.lu-label')!.innerHTML = labelInnerHTML;
+  node.querySelector('.lu-label')!.innerHTML = col.label + importMarker(col.guessed);
   node.title = toFullTooltip(col);
 
   const sort = <HTMLElement>node.querySelector(`i[title='Sort']`)!;

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -74,7 +74,9 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
   `;
 
   if(col.guessed !== EGuessedState.unknown) {
-    node.querySelector('.lu-label')!.innerHTML += `<i class="fa fa-${col.guessed === EGuessedState.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
+    const labelElement = node.querySelector('.lu-label');
+    labelElement!.innerHTML += `<i class="fa fa-${col.guessed === EGuessedState.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
+    labelElement!.classList.add('has-marker');
   }
 
   const dialogBackdropMask:() => IMaskRect = () => {

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -73,6 +73,10 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
     <div class="lu-handle"></div>
   `;
 
+  if(typeof col.guessed !== 'undefined' && col.guessed !== null) {
+    node.querySelector('.lu-label').innerHTML += `<i class="fa fa-${col.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
+  }
+
   const dialogBackdropMask:() => IMaskRect = () => {
     const mask = node.getBoundingClientRect();
     // manipulate bottom to highlight the whole column (and not only the header)
@@ -99,7 +103,11 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
 }
 
 export function updateHeader(node: HTMLElement, col: Column, ctx: IRankingHeaderContext, interactive: boolean = false) {
-  node.querySelector('.lu-label')!.innerHTML = col.label;
+  let labelInnerHTML = col.label;
+  if(typeof col.guessed !== 'undefined' && col.guessed !== null) {
+    labelInnerHTML += `<i class="fa fa-${col.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
+  }
+  node.querySelector('.lu-label')!.innerHTML = labelInnerHTML;
   node.title = toFullTooltip(col);
 
   const sort = <HTMLElement>node.querySelector(`i[title='Sort']`)!;

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -58,14 +58,14 @@ export interface IHeaderOptions {
 }
 
 function importMarker(state: EGuessedState): string {
-  if(state === EGuessedState.unknown) {
+  if(state === EGuessedState.UNKNOWN) {
     return '';
   }
 
   let icon = 'fa-check';
   let title = `The imported data type has been confirmed.`;
 
-  if(state === EGuessedState.guessed) {
+  if(state === EGuessedState.GUESSED) {
     icon = 'fa-question';
     title = `The imported data type was guessed automatically.`;
   }
@@ -89,7 +89,7 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
     <div class="lu-handle"></div>
   `;
 
-  if(col.guessed !== EGuessedState.unknown) {
+  if(col.guessed !== EGuessedState.UNKNOWN) {
     const labelElement = node.querySelector('.lu-label');
     labelElement!.innerHTML += importMarker(col.guessed);
     labelElement!.classList.add('has-marker');

--- a/src/ui/engine/header.ts
+++ b/src/ui/engine/header.ts
@@ -74,7 +74,7 @@ export function createHeader(col: Column, document: Document, ctx: IRankingHeade
   `;
 
   if(col.guessed !== EGuessedState.unknown) {
-    node.querySelector('.lu-label').innerHTML += `<i class="fa fa-${col.guessed === EGuessedState.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
+    node.querySelector('.lu-label')!.innerHTML += `<i class="fa fa-${col.guessed === EGuessedState.guessed ? Column.GUESSED_ICON : Column.CONFIRMED_ICON}"></i>`;
   }
 
   const dialogBackdropMask:() => IMaskRect = () => {


### PR DESCRIPTION
required for Caleydo/lineup#25

Adds a new flag for columns. With this flag it is possible to indicate to the user whether the type of a column was guessed or chosen by the user. Guessed columns are displayed with a cross next to the column name:
![grafik](https://user-images.githubusercontent.com/36196885/36997878-5e96e32a-20bb-11e8-9159-e694cc520c04.png)

Columns that are chosen by the user are displayed with a tick:
![grafik](https://user-images.githubusercontent.com/36196885/36997861-511433a6-20bb-11e8-8c65-512238228663.png)
